### PR TITLE
Add support for u8g2

### DIFF
--- a/set-displays.sh
+++ b/set-displays.sh
@@ -33,3 +33,28 @@ else
   sed "/^ *UCG_DISPLAY_TABLE_ENTRY(ili.*)/d" ucg_config.h > ucg_config.h.tmp && mv ucg_config.h.tmp ucg_config.h
   sed "s/^ *UCG_DISPLAY_TABLE_ENTRY.*)/    UCG_DISPLAY_TABLE_ENTRY($X_UCG_DISPLAY_SPI)/" ucg_config.h > ucg_config.h.tmp && mv ucg_config.h.tmp ucg_config.h
 fi
+
+
+# replace default U8G2 I2C/SPI displays with the selected ones
+
+if [ "${X_U8G2_DISPLAY_I2C}" == "" ]; then
+  # one *could* delete the default entry if no display is selected...
+  :
+else
+  cat <<EOF > u8g2_displays.h.tmp
+#define U8G2_DISPLAY_TABLE_I2C_EXTRA \\
+  U8G2_DISPLAY_TABLE_ENTRY(u8g2_Setup_${X_U8G2_DISPLAY_I2C}_f, ${X_U8G2_DISPLAY_I2C})
+EOF
+  cat u8g2_displays.h >> u8g2_displays.h.tmp && mv u8g2_displays.h.tmp u8g2_displays.h
+fi
+
+if [ "${X_U8G2_DISPLAY_SPI}" == "" ]; then
+  # one *could* delete the default entry if no display is selected...
+  :
+else
+  cat <<EOF > u8g2_displays.h.tmp
+#define U8G2_DISPLAY_TABLE_SPI_EXTRA \\
+  U8G2_DISPLAY_TABLE_ENTRY(u8g2_Setup_${X_U8G2_DISPLAY_SPI}_f, ${X_U8G2_DISPLAY_SPI})
+EOF
+  cat u8g2_displays.h >> u8g2_displays.h.tmp && mv u8g2_displays.h.tmp u8g2_displays.h
+fi

--- a/set-displays.sh
+++ b/set-displays.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# replace default U8G I2C/SPI displays with the selected ones
+# replace default U8G and U8G2 I2C/SPI displays with the selected ones
 # sed inline in-place editing (-i) isn't used because OS X would require different syntax http://stackoverflow.com/q/22521207/131929
 
 if [ "${X_U8G_DISPLAY_I2C}" == "" ]; then
@@ -10,7 +10,17 @@ if [ "${X_U8G_DISPLAY_I2C}" == "" ]; then
   # sed "/^ *U8G_DISPLAY_TABLE_ENTRY.*i2c)/d" u8g_config.h
   :
 else
-  sed "s/^ *U8G_DISPLAY_TABLE_ENTRY.*i2c)/    U8G_DISPLAY_TABLE_ENTRY($X_U8G_DISPLAY_I2C)/" u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
+  if test -e "u8g_config.h"; then
+    sed "s/^ *U8G_DISPLAY_TABLE_ENTRY.*i2c)/    U8G_DISPLAY_TABLE_ENTRY($X_U8G_DISPLAY_I2C)/" u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
+  fi
+
+  if test -e "u8g2_displays.h"; then
+    cat <<EOF > u8g2_displays.h.tmp
+#define U8G2_DISPLAY_TABLE_I2C_EXTRA \\
+  U8G2_DISPLAY_TABLE_ENTRY(u8g2_Setup_${X_U8G_DISPLAY_I2C}_f, ${X_U8G_DISPLAY_I2C})
+EOF
+    cat u8g2_displays.h >> u8g2_displays.h.tmp && mv u8g2_displays.h.tmp u8g2_displays.h
+  fi
 fi
 
 if [ "${X_U8G_DISPLAY_SPI}" == "" ]; then
@@ -18,7 +28,17 @@ if [ "${X_U8G_DISPLAY_SPI}" == "" ]; then
   # sed "/^ *U8G_DISPLAY_TABLE_ENTRY.*spi)/d" u8g_config.h
   :
 else
-  sed "s/^ *U8G_DISPLAY_TABLE_ENTRY.*spi)/    U8G_DISPLAY_TABLE_ENTRY($X_U8G_DISPLAY_SPI)/" u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
+  if test -e "u8g_config.h"; then
+    sed "s/^ *U8G_DISPLAY_TABLE_ENTRY.*spi)/    U8G_DISPLAY_TABLE_ENTRY($X_U8G_DISPLAY_SPI)/" u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
+  fi
+
+  if test -e "u8g2_displays.h"; then
+    cat <<EOF > u8g2_displays.h.tmp
+#define U8G2_DISPLAY_TABLE_SPI_EXTRA \\
+  U8G2_DISPLAY_TABLE_ENTRY(u8g2_Setup_${X_U8G_DISPLAY_SPI}_f, ${X_U8G_DISPLAY_SPI})
+EOF
+    cat u8g2_displays.h >> u8g2_displays.h.tmp && mv u8g2_displays.h.tmp u8g2_displays.h
+  fi
 fi
 
 
@@ -32,29 +52,4 @@ else
   # delete the first of two default entries and replace the second
   sed "/^ *UCG_DISPLAY_TABLE_ENTRY(ili.*)/d" ucg_config.h > ucg_config.h.tmp && mv ucg_config.h.tmp ucg_config.h
   sed "s/^ *UCG_DISPLAY_TABLE_ENTRY.*)/    UCG_DISPLAY_TABLE_ENTRY($X_UCG_DISPLAY_SPI)/" ucg_config.h > ucg_config.h.tmp && mv ucg_config.h.tmp ucg_config.h
-fi
-
-
-# replace default U8G2 I2C/SPI displays with the selected ones
-
-if [ "${X_U8G2_DISPLAY_I2C}" == "" ]; then
-  # one *could* delete the default entry if no display is selected...
-  :
-else
-  cat <<EOF > u8g2_displays.h.tmp
-#define U8G2_DISPLAY_TABLE_I2C_EXTRA \\
-  U8G2_DISPLAY_TABLE_ENTRY(u8g2_Setup_${X_U8G2_DISPLAY_I2C}_f, ${X_U8G2_DISPLAY_I2C})
-EOF
-  cat u8g2_displays.h >> u8g2_displays.h.tmp && mv u8g2_displays.h.tmp u8g2_displays.h
-fi
-
-if [ "${X_U8G2_DISPLAY_SPI}" == "" ]; then
-  # one *could* delete the default entry if no display is selected...
-  :
-else
-  cat <<EOF > u8g2_displays.h.tmp
-#define U8G2_DISPLAY_TABLE_SPI_EXTRA \\
-  U8G2_DISPLAY_TABLE_ENTRY(u8g2_Setup_${X_U8G2_DISPLAY_SPI}_f, ${X_U8G2_DISPLAY_SPI})
-EOF
-  cat u8g2_displays.h >> u8g2_displays.h.tmp && mv u8g2_displays.h.tmp u8g2_displays.h
 fi

--- a/set-fonts.sh
+++ b/set-fonts.sh
@@ -5,21 +5,20 @@ set -e
 if [ "${X_U8G_FONTS}" == "" ]; then
   export X_U8G_FONTS_STRING=' '
 else
-  # replace ',' by newline and turn every item into '    U8G_FONT_TABLE_ENTRY(<font-name>) \' (except
-  # the one on the last line which mustn't have the '\'
-  export X_U8G_FONTS_STRING=$(echo $X_U8G_FONTS | tr , '\n' | perl -pe 'my $break = (eof) ? "" : "\\"; s/(.*)\n/    U8G_FONT_TABLE_ENTRY($1) $break\n/g')
+  if test -e "u8g_config.h"; then
+    # replace ',' by newline and turn every item into '    U8G_FONT_TABLE_ENTRY(<font-name>) \' (except
+    # the one on the last line which mustn't have the '\'
+    export X_U8G_FONTS_STRING=$(echo $X_U8G_FONTS | tr , '\n' | perl -pe 'my $break = (eof) ? "" : "\\"; s/(.*)\n/    U8G_FONT_TABLE_ENTRY($1) $break\n/g')
 
-  # inject the fonts string into u8g_config.h between '#define U8G_FONT_TABLE \\n' and '\n#undef U8G_FONT_TABLE_ENTRY'
-  # the 's' flag in '/sg' makes . match newlines
-  # Perl creates a temp file which is removed right after the manipulation
-  perl -e 'local $/; $_ = <>; s/(#define U8G_FONT_TABLE *\\\n)(.*)(\n#undef U8G_FONT_TABLE_ENTRY)/$1$ENV{"X_U8G_FONTS_STRING"}$3/sg; print' u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
-fi
+    # inject the fonts string into u8g_config.h between '#define U8G_FONT_TABLE \\n' and '\n#undef U8G_FONT_TABLE_ENTRY'
+    # the 's' flag in '/sg' makes . match newlines
+    # Perl creates a temp file which is removed right after the manipulation
+    perl -e 'local $/; $_ = <>; s/(#define U8G_FONT_TABLE *\\\n)(.*)(\n#undef U8G_FONT_TABLE_ENTRY)/$1$ENV{"X_U8G_FONTS_STRING"}$3/sg; print' u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
+  fi
 
-
-if [ "${X_U8G2_FONTS}" == "" ]; then
-  :
-else
-  echo "#define U8G2_FONT_TABLE_EXTRA \\" > u8g2_fonts.h.tmp
-  echo $X_U8G2_FONTS | tr , '\n' | sed "s/\(.*\)/   U8G2_FONT_TABLE_ENTRY(\1) \\\\/" >> u8g2_fonts.h.tmp
-  cat u8g2_fonts.h >> u8g2_fonts.h.tmp && mv u8g2_fonts.h.tmp u8g2_fonts.h
+  if test -e "u8g2_fonts.h"; then
+    echo "#define U8G2_FONT_TABLE_EXTRA \\" > u8g2_fonts.h.tmp
+    echo $X_U8G_FONTS | tr , '\n' | sed "s/\(.*\)/   U8G2_FONT_TABLE_ENTRY(\1) \\\\/" >> u8g2_fonts.h.tmp
+    cat u8g2_fonts.h >> u8g2_fonts.h.tmp && mv u8g2_fonts.h.tmp u8g2_fonts.h
+  fi
 fi

--- a/set-fonts.sh
+++ b/set-fonts.sh
@@ -8,8 +8,18 @@ else
   # replace ',' by newline and turn every item into '    U8G_FONT_TABLE_ENTRY(<font-name>) \' (except
   # the one on the last line which mustn't have the '\'
   export X_U8G_FONTS_STRING=$(echo $X_U8G_FONTS | tr , '\n' | perl -pe 'my $break = (eof) ? "" : "\\"; s/(.*)\n/    U8G_FONT_TABLE_ENTRY($1) $break\n/g')
+
+  # inject the fonts string into u8g_config.h between '#define U8G_FONT_TABLE \\n' and '\n#undef U8G_FONT_TABLE_ENTRY'
+  # the 's' flag in '/sg' makes . match newlines
+  # Perl creates a temp file which is removed right after the manipulation
+  perl -e 'local $/; $_ = <>; s/(#define U8G_FONT_TABLE *\\\n)(.*)(\n#undef U8G_FONT_TABLE_ENTRY)/$1$ENV{"X_U8G_FONTS_STRING"}$3/sg; print' u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
 fi
-# inject the fonts string into u8g_config.h between '#define U8G_FONT_TABLE \\n' and '\n#undef U8G_FONT_TABLE_ENTRY'
-# the 's' flag in '/sg' makes . match newlines
-# Perl creates a temp file which is removed right after the manipulation
-perl -e 'local $/; $_ = <>; s/(#define U8G_FONT_TABLE *\\\n)(.*)(\n#undef U8G_FONT_TABLE_ENTRY)/$1$ENV{"X_U8G_FONTS_STRING"}$3/sg; print' u8g_config.h > u8g_config.h.tmp && mv u8g_config.h.tmp u8g_config.h
+
+
+if [ "${X_U8G2_FONTS}" == "" ]; then
+  :
+else
+  echo "#define U8G2_FONT_TABLE_EXTRA \\" > u8g2_fonts.h.tmp
+  echo $X_U8G2_FONTS | tr , '\n' | sed "s/\(.*\)/   U8G2_FONT_TABLE_ENTRY(\1) \\\\/" >> u8g2_fonts.h.tmp
+  cat u8g2_fonts.h >> u8g2_fonts.h.tmp && mv u8g2_fonts.h.tmp u8g2_fonts.h
+fi


### PR DESCRIPTION
This adds support for the u8g2 config files in nodemcu/nodemcu-firmware#2184.

I checked the scripts on my feature branch - they perform as expected.
They are supposed to be backward compatible, although I had to move the `perl` script into the else branch in `set-fonts.sh` to avoid fails in the absence of u8g. I don't expect that this will break things, though I didn't understand why the perl script was executed unconditionally.
