### PR TITLE
remove condition to set LFS and SPIFFS configuration in user_config.h

### DIFF
--- a/build.config
+++ b/build.config
@@ -1,4 +1,4 @@
-email=onypxubyr@abjurer
+email=suvft@rkpvgr.pbz
 branch=master
 modules=node,file,gpio,wifi,net,tmr,uart,mqtt,spi,http,ucg,u8g
 ssl-enabled=true

--- a/build.config
+++ b/build.config
@@ -1,4 +1,4 @@
-email=suvft@rkpvgr.pbz
+email=onypxubyr@abjurer
 branch=master
 modules=node,file,gpio,wifi,net,tmr,uart,mqtt,spi,http,ucg,u8g
 ssl-enabled=true

--- a/set-config.sh
+++ b/set-config.sh
@@ -15,8 +15,6 @@ set -e
 
 # Only process LUA_FLASH_STORE and SPIFFS commands if SDK 2.x (no PARTITIONS defined)
 
-if [ 0 -eq "$(grep NODEMCU_EAGLEROM_PARTITION -c user_config.h)" ] ; then
-
 # What is carried in the following variables is the sed replacement expression.
 # It makes all #defines commented by default.
 declare         lfs="// #\\1"
@@ -44,8 +42,6 @@ sed -e "s!^.*\\(define *LUA_FLASH_STORE\\).*!$lfs!" \
     -e "s!^.*\\(define *SPIFFS_MAX_FILESYSTEM_SIZE\\).*!$spiffs_size!" \
     user_config.h > user_config.h.new;
 mv user_config.h.new user_config.h;
-
-fi  # test for NODEMCU_EAGLEROM_PARTITION
 
 # What is carried in the following variables is the sed replacement expression.
 # It makes all #defines commented by default.

--- a/set-config.sh
+++ b/set-config.sh
@@ -4,9 +4,9 @@
 # corresponding env X_???? variable.
 #
 #  Define                  Uncomment if param        Set to param   SDK3.0 ?
-#  LUA_FLASH_STORE                >0                      Y           N
-#  SPIFFS_FIXED_LOCATION          >0                      Y           N
-#  SPIFFS_MAX_FILESYSTEM_SIZE     >0                      Y           N
+#  LUA_FLASH_STORE                >0                      Y           Y
+#  SPIFFS_FIXED_LOCATION          >0                      Y           Y
+#  SPIFFS_MAX_FILESYSTEM_SIZE     >0                      Y           Y
 #  BUILD_FATFS                  "true"                                Y
 #  DEVELOP_VERSION              "true"                                Y
 #  SSL_ENABLED                  "true"                                Y
@@ -14,7 +14,6 @@
 set -e
 
 # Only process LUA_FLASH_STORE and SPIFFS commands if SDK 2.x (no PARTITIONS defined)
-
 # What is carried in the following variables is the sed replacement expression.
 # It makes all #defines commented by default.
 declare         lfs="// #\\1"

--- a/set-config.sh
+++ b/set-config.sh
@@ -13,7 +13,6 @@
 #
 set -e
 
-# Only process LUA_FLASH_STORE and SPIFFS commands if SDK 2.x (no PARTITIONS defined)
 # What is carried in the following variables is the sed replacement expression.
 # It makes all #defines commented by default.
 declare         lfs="// #\\1"


### PR DESCRIPTION
fixes #35 
As detailed in the bug the LFS configuration is also working via user_config.h (legacy) configuration.